### PR TITLE
Create Skill-Testing-Team.md

### DIFF
--- a/team/Skill-Testing-Team.md
+++ b/team/Skill-Testing-Team.md
@@ -1,0 +1,58 @@
+# Skill Testing Team
+
+Our Skill Testing Team are responsible for the [Skills Acceptance Process](https://mycroft.ai/documentation/skills/skills-acceptance-process/). They review all Skills submitted for inclusion to the [Mycroft Marketplace](https://market.mycroft.ai), ensuring that our Skills are secure, stable, accurate, and intuitive.
+
+They are a friendly and helpful team of Community members, always eager to provide tangible advice to Skill Authors.
+
+Team members conduct one or more reviews on incoming pull requests. These include:
+- Code review - ensuring the code is stable and secure
+- Information review - ensuring all info is accurate and understandable
+- Functional review - ensuring the experience of using the Skill is intuitive  
+
+The type of review they choose depends on each members personal skills and interests.
+
+## Team Members
+
+<table>
+  <tr>
+    <td><a href="https://github.com/ConorIA"><img width="40px" src="https://github.com/ConorIA.png?size=40"></a></td>
+    <td><a href="https://github.com/ConorIA">@ConorIA</a></td>
+    <td>Community Member</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/emattei"><img width="40px" src="https://github.com/emattei.png?size=40"></a></td>
+    <td><a href="https://github.com/emattei">@emattei</a></td>
+    <td>Community Member</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/GPVM"><img width="40px" src="https://github.com/GPVM.png?size=40"></a></td>
+    <td><a href="https://github.com/GPVM">@GPVM</a></td>
+    <td>Community Member</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/LinusS1"><img width="40px" src="https://github.com/LinusS1.png?size=40"></a></td>
+    <td><a href="https://github.com/LinusS1">@LinusS1</a></td>
+    <td>Community Member</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/lb803"><img width="40px" src="https://github.com/lb803.png?size=40"></a></td>
+    <td><a href="https://github.com/lb803">@lb803</a></td>
+    <td>Community Member</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/ricargoes"><img width="40px" src="https://github.com/ricargoes.png?size=40"></a></td>
+    <td><a href="https://github.com/ricargoes">@ricargoes</a></td>
+    <td>Community Member</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/krisgesling"><img width="40px" src="https://github.com/krisgesling.png?size=40"></a></td>
+    <td><a href="https://github.com/krisgesling">@krisgesling</a></td>
+    <td>Developer Relations</td>
+  </tr>
+</table>
+
+## Joining the Team
+
+All members of the Skill Testing Team are active leaders in our Community. They are honest and helpful, understanding that contributors bring a diversity of skills and experience to Mycroft.
+
+Applications to join the Team are open - [apply now!](https://goo.gl/forms/mTSRlAsMaMjelX482)


### PR DESCRIPTION
Add first Skill Testing Team page.
Have used html table as the default Github avatars don't resize like the others so have added an explicit width on the cell. The table has an added benefit of vertically aligning the text with the images too.